### PR TITLE
Harden tenant isolation and token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ cp env.example .env
 | `DATABASE_URL` | App connection string (RLS user) |
 | `ADMIN_DATABASE_URL` | Admin connection string (Owner) |
 | `KEYCLOAK_URL` | Keycloak internal URL |
+| `KEYCLOAK_AUDIENCE` | Expected JWT `aud` claim for API access |
 | `ADMIN_API_KEY` | Key for internal admin routes |
 
 ## 6. How It Works
@@ -250,4 +251,3 @@ locust -f load_tests/locustfile.py
 *   **Webhooks:** Trigger external webhooks on specific event types.
 *   **UI Console:** A frontend for admins to browse logs.
 *   **Signature Verification:** Sign event hashes with a private key for non-repudiation.
-

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -62,7 +62,7 @@ async def get_db_with_context(
     try:
         # Use set_config for safer variable setting
         await db.execute(
-            text("SELECT set_config('app.tenant_id', :tenant_id, false)"), 
+            text("SELECT set_config('app.tenant_id', :tenant_id, true)"), 
             {"tenant_id": tenant_id}
         )
     except Exception as e:

--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -114,7 +114,7 @@ async def create_event(
     # Actually, commit() ends the transaction and thus the SET LOCAL.
     # So we MUST re-apply it for the fetch query.
     await db.execute(
-        text("SELECT set_config('app.tenant_id', :tenant_id, false)"), 
+        text("SELECT set_config('app.tenant_id', :tenant_id, true)"), 
         {"tenant_id": tenant_id}
     )
 

--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     KEYCLOAK_REALM: str = "audit-realm"
     KEYCLOAK_ADMIN_USER: str = "admin"
     KEYCLOAK_ADMIN_PASSWORD: str
+    KEYCLOAK_AUDIENCE: str
     
     # Admin Security
     ADMIN_API_KEY: str

--- a/app/core/auth/keycloak.py
+++ b/app/core/auth/keycloak.py
@@ -97,22 +97,19 @@ class KeycloakProvider(IdPProvider):
         Validates JWT signature against Keycloak public key.
         """
         public_key = self.get_public_key()
-        
+
         options = {
             "verify_signature": True,
-            "verify_aud": False, # 'aud' might be 'account' or the client_id, we need to check custom aud if set
+            "verify_aud": True,
             "exp": True
         }
-        
-        # We might want to enforce 'aud' matches 'audit-api' if we configure it that way
-        # For MVP, we trust the signature and the realm.
-        
+
         decoded = jwt.decode(
             token,
             public_key,
             algorithms=["RS256"],
-            options=options
+            options=options,
+            audience=settings.KEYCLOAK_AUDIENCE,
         )
-        
-        return decoded
 
+        return decoded

--- a/env.example
+++ b/env.example
@@ -17,6 +17,7 @@ KEYCLOAK_URL=http://localhost:8080
 KEYCLOAK_REALM=audit-realm
 KEYCLOAK_ADMIN_USER=admin
 KEYCLOAK_ADMIN_PASSWORD=admin
+KEYCLOAK_AUDIENCE=audit-api
 
 # Keycloak Database (Internal)
 KEYCLOAK_DB_NAME=keycloak
@@ -25,4 +26,3 @@ KEYCLOAK_DB_PASSWORD=password
 
 # Security
 ADMIN_API_KEY=dev-admin-key
-


### PR DESCRIPTION
## Summary
- scope tenant context to the current transaction to prevent RLS bleed across pooled connections
- enforce JWT audience validation against the configured Keycloak audience
- document the required audience value in configuration samples and README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c13d5b8748332a884529772724b2d)