### PR TITLE
🧪 [testing improvement] Add edge case test for Event Trace

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,29 @@ async def test_create_event(client: AsyncClient, auth_headers):
     assert data["tenant_id"] == "tenant-A"
 
 @pytest.mark.anyio
+async def test_create_event_with_trace(client: AsyncClient, auth_headers):
+    payload = {
+        "idempotency_key": "test-trace-req-1",
+        "occurred_at": "2025-12-19T10:11:12Z",
+        "type": "user.created",
+        "actor": { "kind": "admin", "id": "admin-1" },
+        "entities": [
+            { "kind": "user", "id": "u-100" }
+        ],
+        "trace": {
+            "trace_id": "t-123",
+            "request_id": "r-456"
+        },
+        "payload": { "email": "test@example.com" }
+    }
+    headers = auth_headers("tenant-A")
+
+    response = await client.post("/v1/events", json=payload, headers=headers)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["trace"] == {"trace_id": "t-123", "request_id": "r-456"}
+
+@pytest.mark.anyio
 async def test_idempotency_same_payload(client: AsyncClient, auth_headers):
     payload = {
         "idempotency_key": "test-req-2",


### PR DESCRIPTION
### 🎯 **What:** The testing gap addressed
This PR addresses the missing test coverage for the `trace` field in the Event creation endpoint.

### 📊 **Coverage:** What scenarios are now tested
- Added `test_create_event_with_trace` to `tests/test_api.py`.
- Verified that sending a payload with a `trace` object (containing `trace_id` and `request_id`) results in the trace being correctly stored and returned in the response.

### ✨ **Result:** The improvement in test coverage
Ensures that the optional `trace` field is properly handled by the API, increasing the reliability of event tracing across services.

---
*PR created automatically by Jules for task [3526625173174123597](https://jules.google.com/task/3526625173174123597) started by @Johaik*