### PR TITLE
🧪 [testing improvement] Add error test for get_timeline invalid entity format

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -153,3 +153,9 @@ async def test_query_events_filter(client: AsyncClient, auth_headers):
     data = response.json()
     assert len(data["events"]) == 2
 
+@pytest.mark.anyio
+async def test_get_timeline_invalid_format(client: AsyncClient, auth_headers):
+    headers = auth_headers("tenant-A")
+    response = await client.get("/v1/timeline?entity=invalidformat", headers=headers)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Entity must be in format kind:id"


### PR DESCRIPTION
🎯 **What:** Missing error test for get_timeline invalid entity format in `app/api/endpoints.py`.
📊 **Coverage:** Added `test_get_timeline_invalid_format` to `tests/test_api.py` to cover the `400 Bad Request` scenario when an entity is provided without the required `kind:id` format.
✨ **Result:** Increased test coverage for the timeline endpoint's input validation logic.

---
*PR created automatically by Jules for task [7579410187623200223](https://jules.google.com/task/7579410187623200223) started by @Johaik*