### PR TITLE
🧹 Refactor init_keycloak.py to use specific KeycloakConnectionError

### DIFF
--- a/scripts/init_keycloak.py
+++ b/scripts/init_keycloak.py
@@ -16,7 +16,7 @@ def wait_for_keycloak(kcadm, max_retries=30):
             kcadm.get_realms()
             print("Connected to Keycloak.")
             return True
-        except Exception:
+        except KeycloakConnectionError:
             print(f"Waiting for Keycloak... ({i+1}/{max_retries})")
             time.sleep(2)
     return False
@@ -31,7 +31,7 @@ def init_keycloak():
             realm_name="master",
             verify=True
         )
-    except Exception as e:
+    except KeycloakConnectionError as e:
         print(f"Failed to initialize Keycloak client: {e}")
         return
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored `scripts/init_keycloak.py` to use `KeycloakConnectionError` instead of generic `Exception` blocks in `wait_for_keycloak` and `init_keycloak`.

💡 **Why:** How this improves maintainability
This resolves an unused import warning for `KeycloakConnectionError` and makes the exception handling significantly more robust by specifically catching connection issues instead of accidentally swallowing other critical errors like `KeyboardInterrupt` or syntax errors.

✅ **Verification:** How you confirmed the change is safe
Reviewed the changes with `request_code_review` to ensure no functionality is broken and that it accurately follows the user's specific request. Ran `py_compile` to check for syntax errors.

✨ **Result:** The improvement achieved
Cleaner, more specific error handling that explicitly uses the imported `KeycloakConnectionError` dependency.

---
*PR created automatically by Jules for task [6336361752516846757](https://jules.google.com/task/6336361752516846757) started by @Johaik*