### PR TITLE
🧪 [testing improvement] Add missing error tests for invalid timeline cursors

### DIFF
--- a/tests/test_deep_read_ops.py
+++ b/tests/test_deep_read_ops.py
@@ -154,3 +154,28 @@ async def test_events_list_filtering(client: AsyncClient, auth_headers):
     assert len(data["events"]) == 1
     assert data["events"][0]["idempotency_key"] == "t1"
 
+@pytest.mark.anyio
+async def test_timeline_invalid_cursor(client: AsyncClient, auth_headers):
+    """
+    Test that an invalid cursor parameter returns a 400 Bad Request.
+    """
+    headers = auth_headers("tenant-timeline-err")
+
+    # Send a request to /timeline with an invalid cursor
+    resp = await client.get("/v1/timeline?entity=order:ord-1&cursor=invalid-cursor-format", headers=headers)
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid cursor format"
+
+@pytest.mark.anyio
+async def test_events_invalid_cursor(client: AsyncClient, auth_headers):
+    """
+    Test that an invalid cursor parameter to /events returns a 400 Bad Request.
+    """
+    headers = auth_headers("tenant-events-err")
+
+    # Send a request to /events with an invalid cursor
+    resp = await client.get("/v1/events?cursor=invalid-cursor-format", headers=headers)
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid cursor format"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing tests for the HTTP 400 Bad Request error returned when an invalid cursor format is passed to either the `/timeline` or `/events` endpoints.

📊 **Coverage:** What scenarios are now tested:
- Sending an invalid cursor string (`"invalid-cursor-format"`) to `GET /v1/timeline` returns a 400 response.
- Sending an invalid cursor string (`"invalid-cursor-format"`) to `GET /v1/events` returns a 400 response.

✨ **Result:** The improvement in test coverage guarantees that both endpoints correctly return a 400 Bad Request rather than resulting in a 500 error or silent failure when invalid cursor strings are used for pagination.

---
*PR created automatically by Jules for task [9130352111943311389](https://jules.google.com/task/9130352111943311389) started by @Johaik*