### PR TITLE
🧪 [Testing Improvement] Add tests for invalid cursor error handling

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,6 +118,20 @@ async def test_get_timeline(client: AsyncClient, auth_headers):
     assert data["events"][0]["type"] == "doc.signed"
 
 @pytest.mark.anyio
+async def test_list_events_invalid_cursor(client: AsyncClient, auth_headers):
+    headers = auth_headers("tenant-A")
+    response = await client.get("/v1/events?cursor=invalid", headers=headers)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid cursor format"
+
+@pytest.mark.anyio
+async def test_get_timeline_invalid_cursor(client: AsyncClient, auth_headers):
+    headers = auth_headers("tenant-A")
+    response = await client.get("/v1/timeline?entity=document:doc-55&cursor=invalid", headers=headers)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid cursor format"
+
+@pytest.mark.anyio
 async def test_query_events_filter(client: AsyncClient, auth_headers):
     headers = auth_headers("tenant-B")
     


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the scenario where an invalid cursor is passed to the `/events` and `/timeline` endpoints.
  
📊 **Coverage:** The scenarios now tested are calling the `/events` endpoint with an invalid cursor and calling the `/timeline` endpoint with an invalid cursor.
  
✨ **Result:** The improvement in test coverage is that the system is now verified to return a 400 Bad Request error with the detail "Invalid cursor format" when an invalid cursor is provided.

---
*PR created automatically by Jules for task [11595107121871926977](https://jules.google.com/task/11595107121871926977) started by @Johaik*