### PR TITLE
🔒 Fix hardcoded default app DB password in init script

### DIFF
--- a/scripts/init_db/01_create_users.sh
+++ b/scripts/init_db/01_create_users.sh
@@ -1,21 +1,31 @@
 #!/bin/bash
 set -e
 
+if [ -z "${APP_DB_PASSWORD}" ]; then
+    echo "ERROR: APP_DB_PASSWORD environment variable is not set or empty. A secure password must be provided."
+    exit 1
+fi
+
+if [ -z "${POSTGRES_USER}" ] || [ -z "${POSTGRES_DB}" ] || [ -z "${APP_DB_USER}" ]; then
+    echo "ERROR: Required environment variables (POSTGRES_USER, POSTGRES_DB, APP_DB_USER) must be set."
+    exit 1
+fi
+
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
     -- Create application user
-    CREATE USER ${APP_DB_USER:-audit_app} WITH PASSWORD '${APP_DB_PASSWORD}';
+    CREATE USER ${APP_DB_USER} WITH PASSWORD '${APP_DB_PASSWORD}';
     
     -- Grant permissions to app user
     -- Note: Schema might not exist yet if created by Alembic later.
     -- But we can grant on database
-    GRANT CONNECT ON DATABASE ${POSTGRES_DB:-audit_db} TO ${APP_DB_USER:-audit_app};
-    GRANT USAGE, CREATE ON SCHEMA public TO ${APP_DB_USER:-audit_app};
+    GRANT CONNECT ON DATABASE ${POSTGRES_DB} TO ${APP_DB_USER};
+    GRANT USAGE, CREATE ON SCHEMA public TO ${APP_DB_USER};
     
     -- Ensure admin user has BYPASSRLS
-    ALTER ROLE ${POSTGRES_USER:-audit_admin} WITH BYPASSRLS;
+    ALTER ROLE ${POSTGRES_USER} WITH BYPASSRLS;
     
     -- Grant future table permissions to app user
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO ${APP_DB_USER:-audit_app};
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO ${APP_DB_USER:-audit_app};
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO ${APP_DB_USER};
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO ${APP_DB_USER};
 EOSQL
 


### PR DESCRIPTION
🎯 **What:** The database initialization script (`01_create_users.sh`) previously relied on a hardcoded default password (`audit_app_password` or an empty default) for the `audit_app` user.
⚠️ **Risk:** If an administrator failed to provide a strong, explicit password via the `APP_DB_PASSWORD` environment variable, the database would silently configure a weak, predictable default password, leaving the application database highly vulnerable to unauthorized access.
🛡️ **Solution:** The script has been updated to strictly enforce the presence of required environment variables (`APP_DB_PASSWORD`, `POSTGRES_USER`, `POSTGRES_DB`, and `APP_DB_USER`). If any of these are unset or empty, the script will now immediately exit with a descriptive error message. Furthermore, all fallback default values (`:-value`) have been removed from the SQL commands, ensuring the database is only provisioned according to explicitly defined secure configurations.

---
*PR created automatically by Jules for task [8788642774475548584](https://jules.google.com/task/8788642774475548584) started by @Johaik*