### PR TITLE
🧹 [code health improvement] remove unused JSON and datetime imports in app/models.py

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,5 @@
 import uuid
-from datetime import datetime
-from sqlalchemy import Column, String, DateTime, func, JSON, Integer, ForeignKey, Index, UniqueConstraint, text
+from sqlalchemy import Column, String, DateTime, func, Integer, ForeignKey, Index, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from app.database import Base


### PR DESCRIPTION
🎯 **What:** Removed unused `JSON` from `sqlalchemy` and `datetime` from `datetime` in `app/models.py`.
💡 **Why:** Having unused imports adds clutter to the codebase and can cause minor IDE warnings. `JSON` was imported but only `JSONB` from PostgreSQL dialects is ever used. `datetime.datetime` was also unused, as the models simply use `func.now()` for dates.
✅ **Verification:** Verified that tests pass (with expected DB missing connection errors) and `ruff` linter confirms `app/models.py` has no unused imports or syntax issues.
✨ **Result:** Cleaned up `app/models.py` imports, improving codebase health.

---
*PR created automatically by Jules for task [3162052506938592182](https://jules.google.com/task/3162052506938592182) started by @Johaik*