### PR TITLE
🧹 Remove unused imports Any and Dict from app/core/logging.py

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -1,7 +1,6 @@
 import structlog
 import logging
 import sys
-from typing import Any, Dict
 
 def setup_logging():
     # standard python logging configuration


### PR DESCRIPTION
🎯 **What:** Removed unused imports `Any` and `Dict` from `app/core/logging.py`.
💡 **Why:** Improves code maintainability and readability by removing dead code.
✅ **Verification:** Verified by compiling the file and running a verification script with mocked dependencies. Confirmed both `Any` and `Dict` are not used in the file using `grep`.
✨ **Result:** A cleaner `app/core/logging.py` without unnecessary imports.

---
*PR created automatically by Jules for task [2613561845489995319](https://jules.google.com/task/2613561845489995319) started by @Johaik*